### PR TITLE
Adds inspect methods, and tons of extraneous refactors

### DIFF
--- a/lib/geomotion/cg_point.rb
+++ b/lib/geomotion/cg_point.rb
@@ -6,7 +6,7 @@ class CGPoint
 
   # size = CGSize.make width: 100, height: 100
   # point = CPPoint.make x:0, y:10
-  # point.rect_of_size(point)  # => CGRect([0, 10], [100, 100])
+  # point.rect_of_size(size)  # => CGRect([0, 10], [100, 100])
   # point.rect_of_size([10, 20])  # => CGRect([10, 20], [100, 100])
   def rect_of_size(size)
     CGRect.new([self.x, self.y], size)

--- a/lib/geomotion/cg_point.rb
+++ b/lib/geomotion/cg_point.rb
@@ -41,4 +41,8 @@ class CGPoint
     self.+(-other)
   end
 
+  def inspect
+    "#{self.class.name}(#{self.x}, #{self.y})"
+  end
+
 end

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -172,9 +172,9 @@ class CGRect
     CGRect.new([self.x + self.width + margin, self.y], self.size)
   end
 
-  def center(relative = false)
-    offset_x = relative ? self.x : 0
-    offset_y = relative ? self.y : 0
+  def center(absolute = false)
+    offset_x = absolute ? self.x : 0
+    offset_y = absolute ? self.y : 0
     CGPoint.new(offset_x + self.width / 2, offset_y + self.height / 2)
   end
 
@@ -182,9 +182,9 @@ class CGRect
     CGRect.new([self.x.round, self.y.round], [self.width.round, self.height.round])
   end
 
-  def centered_in(rect, relative = false)
-    offset_x = relative ? rect.x : 0
-    offset_y = relative ? rect.y : 0
+  def centered_in(rect, absolute = false)
+    offset_x = absolute ? rect.x : 0
+    offset_y = absolute ? rect.y : 0
     CGRect.new([offset_x + ((rect.width - self.width) / 2),
                 offset_y + ((rect.height - self.height) / 2)], self.size)
   end

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -1,6 +1,12 @@
 class CGRect
-  # CGRect.make(x: 10, y: 30)
+  # CGRect.make  # default rect: {origin: {x: 0, y: 0}, size: {width:0, height:0}}
+  #              # aka CGRectZero
+  # CGRect.make(x: 10, y: 30)  # default size: [0, 0]
   # CGRect.make(x: 10, y: 30, width:100, height: 20)
+  #
+  # point = CGPoint.make(x: 10, y: 30)
+  # size = CGSize.make(width: 100, height: 20)
+  # CGRect.make(origin: point, size: size)
   def self.make(options = {})
     if options[:origin]
       options[:x] = options[:origin].x
@@ -23,7 +29,13 @@ class CGRect
   end
 
   def self.infinite
-    self.new([0, 0], CGSize.infinite)
+    # This actually returns the not-very-infinite value of:
+    # [[-1.7014114289565e+38, -1.7014114289565e+38], [3.402822857913e+38, 3.402822857913e+38]]
+    # originally this method returned [[-Infinity, -Infinity], [Infinity, Infinity]],
+    # but that rect ended up returning `false` for any point in the method
+    # CGRect.infinite.contains?(point).  CGRectInfinite returns `true` for any
+    # (sensible) point, so we'll go with that instead
+    CGRectInfinite.dup
   end
 
   # OPTIONS: [:above, :below, :left_of, :right_of, :margins]
@@ -224,7 +236,7 @@ class CGRect
     when CGRect
       CGRectIntersectsRect(self, rect)
     else
-      super
+      super  # raises an error
     end
   end
 
@@ -235,7 +247,7 @@ class CGRect
     when CGRect
       CGRectContainsRect(self, rect_or_point)
     else
-      super
+      super  # raises an error
     end
   end
 

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -72,6 +72,7 @@ class CGRect
     rect
   end
 
+  # bounds
   def min_x
     CGRectGetMinX(self)
   end
@@ -88,6 +89,7 @@ class CGRect
     CGRectGetMaxY(self)
   end
 
+  # getters/setters
   def x(setter = nil)
     if setter
       return CGRect.new([setter, self.y], self.size)
@@ -132,6 +134,7 @@ class CGRect
     self.size.height = _height
   end
 
+  # modified rects
   def left(dist = 0)
     CGRect.new([self.x - dist, self.y], self.size)
   end
@@ -164,6 +167,7 @@ class CGRect
     CGRect.new(self.origin, [self.width, self.height - dist])
   end
 
+  # adjacent rects
   def above(margin = 0)
     self.above(margin, height:self.height)
   end
@@ -192,12 +196,14 @@ class CGRect
     CGRect.new([self.x + self.width + margin, self.y], [width, self.height])
   end
 
+  # locations
   def center(absolute = false)
     offset_x = absolute ? self.x : 0
     offset_y = absolute ? self.y : 0
     CGPoint.new(offset_x + self.width / 2, offset_y + self.height / 2)
   end
 
+  # others
   def round
     CGRect.new([self.x.round, self.y.round], [self.width.round, self.height.round])
   end

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -50,11 +50,11 @@ class CGRect
   # EX CGRect.layout(rect1, above: rect2, left_of: rect3, margins: [0, 10, 20, 0])
   def self.layout(rect1, options)
     if options.empty?
-      p "No options provided in CGRect.layout"
+      p "No options provided in #{self.class}.layout"
       return rect1
     end
 
-    rect = CGRect.new
+    rect = self.new
     rect.size = rect1.size
 
     options[:margins] ||= []

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -9,14 +9,20 @@ class CGRect
   # CGRect.make(origin: point, size: size)
   def self.make(options = {})
     if options[:origin]
-      options[:x] = options[:origin].x
-      options[:y] = options[:origin].y
+      x = options[:origin].x
+      y = options[:origin].y
+    else
+      x = options[:x] || 0
+      y = options[:y] || 0
     end
     if options[:size]
-      options[:width] = options[:size].width
-      options[:height] = options[:size].height
+      w = options[:size].width
+      h = options[:size].height
+    else
+      w = options[:width] || 0
+      h = options[:height] || 0
     end
-    CGRect.new([options[:x] || 0, options[:y] || 0], [options[:width] || 0, options[:height] || 0])
+    self.new([x, y], [w, h])
   end
 
   def self.empty

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -148,6 +148,22 @@ class CGRect
     CGRect.new([self.x, self.y + dist], self.size)
   end
 
+  def wider(dist)
+    CGRect.new(self.origin, [self.width + dist, self.height])
+  end
+
+  def thinner(dist)
+    CGRect.new(self.origin, [self.width - dist, self.height])
+  end
+
+  def taller(dist)
+    CGRect.new(self.origin, [self.width, self.height + dist])
+  end
+
+  def shorter(dist)
+    CGRect.new(self.origin, [self.width, self.height - dist])
+  end
+
   def above(margin = 0)
     self.above(margin, height:self.height)
   end

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -251,4 +251,8 @@ class CGRect
     self.+(-other)
   end
 
+  def inspect
+    "#{self.class.name}([#{self.origin.x}, #{self.origin.y}], [#{self.size.width}, #{self.size.height}])"
+  end
+
 end

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -183,10 +183,7 @@ class CGRect
   end
 
   def centered_in(rect, absolute = false)
-    offset_x = absolute ? rect.x : 0
-    offset_y = absolute ? rect.y : 0
-    CGRect.new([offset_x + ((rect.width - self.width) / 2),
-                offset_y + ((rect.height - self.height) / 2)], self.size)
+    self.size.centered_in(rect, absolute)
   end
 
   def +(other)

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -20,12 +20,13 @@ class CGRect
   end
 
   def self.empty
-    # Don't return CGRectZero; can be mutated
-    CGRect.make
+    # Don't just return CGRectZero; can be mutated
+    CGRectZero.dup
   end
 
   def self.null
-    CGRectNull
+    # Don't just return CGRectNull; can be mutated
+    CGRectNull.dup
   end
 
   def self.infinite
@@ -224,7 +225,7 @@ class CGRect
   end
 
   def infinite?
-    self.size.infinite?
+    self.size.infinite? || CGRectEqualToRect(self, CGRectInfinite)
   end
 
   def null?

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -203,6 +203,22 @@ class CGRect
     CGPoint.new(offset_x + self.width / 2, offset_y + self.height / 2)
   end
 
+  def top_left
+    CGPoint.new(CGRectGetMinX(self), CGRectGetMinY(self))
+  end
+
+  def top_right
+    CGPoint.new(CGRectGetMaxX(self), CGRectGetMinY(self))
+  end
+
+  def bottom_left
+    CGPoint.new(CGRectGetMinX(self), CGRectGetMaxY(self))
+  end
+
+  def bottom_right
+    CGPoint.new(CGRectGetMaxX(self), CGRectGetMaxY(self))
+  end
+
   # others
   def round
     CGRect.new([self.x.round, self.y.round], [self.width.round, self.height.round])

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -185,7 +185,11 @@ class CGRect
   end
 
   def beside(margin = 0)
-    CGRect.new([self.x + self.width + margin, self.y], self.size)
+    self.beside(margin, width: self.width)
+  end
+
+  def beside(margin = 0, width:width)
+    CGRect.new([self.x + self.width + margin, self.y], [width, self.height])
   end
 
   def center(absolute = false)

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -188,7 +188,7 @@ class CGRect
     self.beside(margin, width: self.width)
   end
 
-  def beside(margin = 0, width:width)
+  def beside(margin, width:width)
     CGRect.new([self.x + self.width + margin, self.y], [width, self.height])
   end
 

--- a/lib/geomotion/cg_size.rb
+++ b/lib/geomotion/cg_size.rb
@@ -9,6 +9,10 @@ class CGSize
     CGSizeMake(infinity, infinity)
   end
 
+  def self.empty
+    CGSizeZero.dup
+  end
+
   # size = CGSize.make width: 100, height: 100
   # point = CPPoint.make x:0, y:10
   # size.rect_at_point(point)  # => CGRect([0, 10], [100, 100])

--- a/lib/geomotion/cg_size.rb
+++ b/lib/geomotion/cg_size.rb
@@ -21,6 +21,13 @@ class CGSize
     CGRect.new(point, [self.width, self.height])
   end
 
+  def centered_in(rect, absolute = false)
+    offset_x = absolute ? rect.x : 0
+    offset_y = absolute ? rect.y : 0
+    CGRect.new([offset_x + ((rect.width - self.width) / 2),
+                offset_y + ((rect.height - self.height) / 2)], self)
+  end
+
   def +(other)
     case other
     when CGSize

--- a/lib/geomotion/cg_size.rb
+++ b/lib/geomotion/cg_size.rb
@@ -47,4 +47,8 @@ class CGSize
     self.+(-other)
   end
 
+  def inspect
+    "#{self.class.name}(#{self.width}, #{self.height})"
+  end
+
 end

--- a/spec/cg_rect_spec.rb
+++ b/spec/cg_rect_spec.rb
@@ -328,6 +328,42 @@ describe "CGRect" do
     end
   end
 
+  describe "#top_left" do
+    it "works" do
+      rect = CGRect.make(x: 10, y: 20, width: 100, height: 200)
+      point = rect.top_left
+      point.is_a?(CGPoint).should == true
+      CGPointEqualToPoint(point, CGPointMake(10, 20)).should == true
+    end
+  end
+
+  describe "#bottom_left" do
+    it "works" do
+      rect = CGRect.make(x: 10, y: 20, width: 100, height: 200)
+      point = rect.bottom_left
+      point.is_a?(CGPoint).should == true
+      CGPointEqualToPoint(point, CGPointMake(10, 220)).should == true
+    end
+  end
+
+  describe "#top_right" do
+    it "works" do
+      rect = CGRect.make(x: 10, y: 20, width: 100, height: 200)
+      point = rect.top_right
+      point.is_a?(CGPoint).should == true
+      CGPointEqualToPoint(point, CGPointMake(110, 20)).should == true
+    end
+  end
+
+  describe "#bottom_right" do
+    it "works" do
+      rect = CGRect.make(x: 10, y: 20, width: 100, height: 200)
+      point = rect.bottom_right
+      point.is_a?(CGPoint).should == true
+      CGPointEqualToPoint(point, CGPointMake(110, 220)).should == true
+    end
+  end
+
   describe "#center" do
     it "works" do
       point = CGRect.make(width: 100, height: 100).center

--- a/spec/cg_rect_spec.rb
+++ b/spec/cg_rect_spec.rb
@@ -24,6 +24,15 @@ describe "CGRect" do
     it "should work" do
       CGRectIsEmpty(CGRect.empty).should == true
     end
+
+    it "should not be mutable" do
+      f = CGRect.empty
+      f.width = 10
+      f.height = 10
+      f.x = 10
+      f.y = 10
+      CGRectIsEmpty(CGRect.empty).should == true
+    end
   end
 
   describe "#empty?" do
@@ -37,26 +46,44 @@ describe "CGRect" do
     it "should work" do
       CGRectIsNull(CGRect.null).should == true
     end
+
+    it "should not be mutable" do
+      f = CGRect.null
+      f.width = 10
+      f.height = 10
+      f.x = 10
+      f.y = 10
+      CGRectIsNull(CGRect.null).should == true
+    end
   end
 
   describe "#null?" do
     it "should work" do
       CGRectNull.null?.should == true
+      CGRect.null.null?.should == true
     end
   end
 
   # Currently does NOT work due to some strange RM bug?
-=begin
   describe ".infinite" do
     it "should work" do
-      CGRectIsInfinite(CGRect.infinite).should == true
+      CGRect.infinite.infinite?.should == true
+    end
+
+    it "should not be mutable" do
+      f = CGRect.infinite
+      f.width = 10
+      f.height = 10
+      f.x = 10
+      f.y = 10
+      CGRect.infinite.infinite?.should == true
     end
   end
-=end
 
   describe "#infinite?" do
     it "should work" do
       CGRect.infinite.infinite?.should == true
+      CGRectInfinite.infinite?.should == true
     end
   end
 
@@ -221,6 +248,34 @@ describe "CGRect" do
     end
   end
 
+  describe "#wider" do
+    it "works" do
+      rect = CGRect.empty.wider(20)
+      rect.size.width.should == 20
+    end
+  end
+
+  describe "#thinner" do
+    it "works" do
+      rect = CGRect.empty.thinner(20)
+      rect.size.width.should == -20
+    end
+  end
+
+  describe "#taller" do
+    it "works" do
+      rect = CGRect.empty.taller(20)
+      rect.size.height.should == 20
+    end
+  end
+
+  describe "#shorter" do
+    it "works" do
+      rect = CGRect.empty.shorter(20)
+      rect.size.height.should == -20
+    end
+  end
+
   describe "#above" do
     it "works with margins" do
       rect = CGRect.make(height: 50).above(20)
@@ -263,6 +318,14 @@ describe "CGRect" do
     it "works without margins" do
       rect = CGRect.make(x: 50, width: 20).beside
       rect.origin.x.should == 70
+    end
+  end
+
+  describe "#beside:width:" do
+    it "works" do
+      rect = CGRect.make(x: 50, width: 20).beside(10, width: 30)
+      rect.origin.x.should == 80
+      rect.size.width.should == 30
     end
   end
 

--- a/spec/cg_rect_spec.rb
+++ b/spec/cg_rect_spec.rb
@@ -37,7 +37,6 @@ describe "CGRect" do
 
   describe "#empty?" do
     it "should work" do
-      p "ZERO1 #{CGRectZero.inspect}"
       CGRectZero.empty?.should == true
     end
   end

--- a/spec/cg_size_spec.rb
+++ b/spec/cg_size_spec.rb
@@ -53,6 +53,19 @@ describe "CGSize" do
     end
   end
 
+  describe ".empty" do
+    it "should work" do
+      CGRectIsEmpty(CGSize.empty.rect_at_point([0, 0])).should == true
+    end
+
+    it "should not be mutable" do
+      f = CGSize.empty
+      f.width = 10
+      f.height = 10
+      CGRectIsEmpty(CGSize.empty.rect_at_point([0, 0])).should == true
+    end
+  end
+
   describe "#empty?" do
     it "should return true" do
       empty = CGSizeMake(0, 0)
@@ -71,4 +84,23 @@ describe "CGSize" do
       @size.should != size
     end
   end
+
+  describe "#centered_in" do
+    it "works" do
+      outer_rect = CGRect.make(width: 100, height: 100)
+      inner_size = CGSize.make(width: 50, height: 50)
+
+      centered_rect = inner_size.centered_in(outer_rect)
+      CGRectEqualToRect(centered_rect, CGRectMake(25, 25, 50, 50)).should == true
+    end
+
+    it "works as relative" do
+      outer_rect = CGRect.make(x: 20, y: 30, width: 100, height: 100)
+      inner_size = CGSize.make(width: 50, height: 50)
+
+      centered_rect = inner_size.centered_in(outer_rect, true)
+      CGRectEqualToRect(centered_rect, CGRectMake(45, 55, 50, 50)).should == true
+    end
+  end
+
 end


### PR DESCRIPTION
If you want me to undo some of these, let me know.  I have a terrible habit of moving code around and renaming things.

Not much changes, though I did add `centered_in` to `CGSize` and delegate to that in `CGRect#centered_in` (since `origin` is not used in that method, it made sense to do this).
- added inspect methods so i could remove them from sugarcube
- refactored `CGRect#make` to make all assignments before one generic call to `CGRect##new` (instead of mutating `options`)
- Use more of the CGRectBla constants, like `CGRectInfinite` and `CGRectZero`
- changed `relative` to `absolute`.  Double check, but passing `rect.center(true)` returns the center point in the coordinate system of the parent rect, but `rect.center` returns the point _relative_ to the target frame... (O_o)

So let me know if you want me to undo some of this, I won't be offended.

Congrats again on the book, man! :-D :+1:
