### PR TITLE
Adds CGAffineTransform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: objective-c
+before_install: rvm use 1.9.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    geomotion (0.9.0)
+    geomotion (0.11.0)
 
 GEM
   remote: http://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -257,6 +257,43 @@ point.angle_to(CGPoint.make(x: 20, y:110))
 => 0.785398163397  (pi/4)
 ```
 
+### CGAffineTransform
+
+```ruby
+# you *can* create it manually
+transform = CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 0, ty: 0)
+
+# but don't!  the `make` method accepts `translate`, `scale`, and `rotate` args
+transform = CGAffineTransform.make(scale: 2, translate: [10, 10], rotate: Math::PI)
+
+# identity transform is easy
+CGAffineTransform.identity
+
+# just to be sure
+CGAffineTransform.identity.identity?  # => true
+
+# Operator Overloading
+transform1 = CGAffineTransform.make(scale: 2)
+transform2 = CGAffineTransform.make(translate: [10, 10])
+# concatenate transforms
+transform1 + transform2
+transform1 << transform2  # alias
+transform1 - transform2
+# => transform1 + -transform2
+# => transform1 + transform2.invert
+transform1 - transform1  # => CGAffineTransform.identity
+
+# create new transforms by calling `translate`, `scale`, or `rotate` as factory
+# methods
+CGAffineTransform.translate(10, 10)
+CGAffineTransform.scale(2)
+CGAffineTransform.scale(2, 4)
+CGAffineTransform.rotate(Math::PI / 4)
+
+# or you can chain these methods
+CGAffineTransform.identity.translate(10, 10).scale(2).rotate(Math::PI / 4)
+```
+
 ## Install
 
 1. `gem install geomotion`

--- a/lib/geomotion/cg_affine_transform.rb
+++ b/lib/geomotion/cg_affine_transform.rb
@@ -1,0 +1,173 @@
+class CGAffineTransform
+  # CGAffineTransform.make  # default transform: identity matrix
+  # # make a transform from scratch
+  # CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 0, ty: 0)
+  #
+  # # make a transform using primitives
+  # CGAffineTransform.make(scale: 2, translate: [10, 10], rotate: Math::PI)
+  def self.make(options = {})
+    if options[:a]
+      a = options[:a]
+      raise "`:a` is required" unless a
+      b = options[:b]
+      raise "`:b` is required" unless b
+      c = options[:c]
+      raise "`:c` is required" unless c
+      d = options[:d]
+      raise "`:d` is required" unless d
+      tx = options[:tx]
+      raise "`:tx` is required" unless tx
+      ty = options[:ty]
+      raise "`:ty` is required" unless ty
+      return self.new(a, b, c, d, tx, ty)
+    else
+      retval = self.identity
+      if options[:translate]
+        retval = retval.translate(options[:translate])
+      end
+      if options[:scale]
+        retval = retval.scale(options[:scale])
+      end
+      if options[:rotate]
+        retval = retval.rotate(options[:rotate])
+      end
+      return retval
+    end
+  end
+
+  # Returns a transform that is translated. Accepts one or two arguments. One
+  # argument can be a Point or Array with two items, two arguments should be the
+  # x and y values.
+  # @return CGAffineTransform
+  def self.translate(point, y=nil)
+    if y
+      x = point
+    elsif point.is_a?(Numeric)
+      x = y = point
+    else
+      x = point[0]
+      y = point[1]
+    end
+    CGAffineTransformMakeTranslation(x, y)
+  end
+
+  # Returns a transform that is scaled. Accepts one or two arguments. One
+  # argument can be a Point or Array with two items, two arguments should be the
+  # x and y values.
+  def self.scale(scale, sy=nil)
+    if sy
+      sx = scale
+    elsif scale.is_a?(Numeric)
+      sx = sy = scale
+    else
+      sx = scale[0]
+      sy = scale[1]
+    end
+    CGAffineTransformMakeScale(sx, sy)
+  end
+
+  # Returns a transform that is rotated by `angle` (+ => counterclockwise, - => clockwise)
+  # @return CGAffineTransform
+  def self.rotate(angle)
+    CGAffineTransformMakeRotation(angle)
+  end
+
+  # Returns the CGAffineTransform identity matrix
+  # @return CGAffineTransform
+  def self.identity
+    CGAffineTransformIdentity
+  end
+
+  # Return true if the receiver is the identity matrix, false otherwise
+  # @return CGAffineTransform
+  def identity?
+    CGAffineTransformIsIdentity(self)
+  end
+
+  # @return [Boolean] true if the two matrices are equal
+  def ==(transform)
+    CGAffineTransformEqualToTransform(self, transform)
+  end
+
+  # Returns self
+  # @return CGAffineTransform
+  def +@
+    self
+  end
+
+  # Concatenates the two transforms
+  # @return CGAffineTransform
+  def +(transform)
+    CGAffineTransformConcat(self, transform)
+  end
+
+  # Concatenates the two transforms
+  # @return CGAffineTransform
+  def <<(transform)
+    CGAffineTransformConcat(self, transform)
+  end
+
+  # Inverts the transform
+  # @return CGAffineTransform
+  def -@
+    CGAffineTransformInvert(self)
+  end
+
+  # Inverts the second transform and adds the result to `self`
+  # @return CGAffineTransform
+  def -(transform)
+    self + -transform
+  end
+
+  # Applies a translation transform to the receiver
+  # @return CGAffineTransform
+  def translate(point, y=nil)
+    if y
+      x = point
+    elsif point.is_a?(Numeric)
+      x = y = point
+    else
+      x = point[0]
+      y = point[1]
+    end
+    CGAffineTransformTranslate(self, x, y)
+  end
+
+  # Applies a scale transform to the receiver
+  # @return CGAffineTransform
+  def scale(scale, sy=nil)
+    if sy
+      sx = scale
+    elsif scale.is_a?(Numeric)
+      sx = sy = scale
+    else
+      sx = scale[0]
+      sy = scale[1]
+    end
+    CGAffineTransformScale(self, sx, sy)
+  end
+
+  # Applies a rotation transform to the receiver
+  # @return CGAffineTransform
+  def rotate(angle)
+    CGAffineTransformRotate(self, angle)
+  end
+
+  def apply_to(thing)
+    case thing
+    when CGPoint
+      CGPointApplyAffineTransform(thing, self)
+    when CGSize
+      CGSizeApplyAffineTransform(thing, self)
+    when CGRect
+      CGRectApplyAffineTransform(thing, self)
+    else
+      raise "Cannot apply transform to #{thing.inspect}"
+    end
+  end
+
+  def to_a
+    [self.a, self.b, self.c, self.d, self.tx, self.ty]
+  end
+
+end

--- a/lib/geomotion/cg_affine_transform.rb
+++ b/lib/geomotion/cg_affine_transform.rb
@@ -6,7 +6,7 @@ class CGAffineTransform
   # # make a transform using primitives
   # CGAffineTransform.make(scale: 2, translate: [10, 10], rotate: Math::PI)
   def self.make(options = {})
-    if options[:a]
+    if options.key?(:a)
       a = options[:a]
       raise "`:a` is required" unless a
       b = options[:b]
@@ -42,8 +42,6 @@ class CGAffineTransform
   def self.translate(point, y=nil)
     if y
       x = point
-    elsif point.is_a?(Numeric)
-      x = y = point
     else
       x = point[0]
       y = point[1]
@@ -52,8 +50,8 @@ class CGAffineTransform
   end
 
   # Returns a transform that is scaled. Accepts one or two arguments. One
-  # argument can be a Point or Array with two items, two arguments should be the
-  # x and y values.
+  # argument can be a Point or Array with two items or a number that will be
+  # used to scale both directions. Two arguments should be the x and y values.
   def self.scale(scale, sy=nil)
     if sy
       sx = scale
@@ -97,35 +95,30 @@ class CGAffineTransform
 
   # Concatenates the two transforms
   # @return CGAffineTransform
-  def +(transform)
+  def concat(transform)
     CGAffineTransformConcat(self, transform)
   end
-
-  # Concatenates the two transforms
-  # @return CGAffineTransform
-  def <<(transform)
-    CGAffineTransformConcat(self, transform)
-  end
-
-  # Inverts the transform
-  # @return CGAffineTransform
-  def -@
-    CGAffineTransformInvert(self)
-  end
+  alias :+ :concat
+  alias :<< :concat
 
   # Inverts the second transform and adds the result to `self`
   # @return CGAffineTransform
   def -(transform)
-    self + -transform
+    self.concat transform.invert
   end
+
+  # Inverts the transform
+  # @return CGAffineTransform
+  def invert
+    CGAffineTransformInvert(self)
+  end
+  alias :-@ :invert
 
   # Applies a translation transform to the receiver
   # @return CGAffineTransform
   def translate(point, y=nil)
     if y
       x = point
-    elsif point.is_a?(Numeric)
-      x = y = point
     else
       x = point[0]
       y = point[1]

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -9,15 +9,15 @@ class CGRect
   # CGRect.make(origin: point, size: size)
   def self.make(options = {})
     if options[:origin]
-      x = options[:origin].x
-      y = options[:origin].y
+      x = options[:origin][0]
+      y = options[:origin][1]
     else
       x = options[:x] || 0
       y = options[:y] || 0
     end
     if options[:size]
-      w = options[:size].width
-      h = options[:size].height
+      w = options[:size][0]
+      h = options[:size][1]
     else
       w = options[:width] || 0
       h = options[:height] || 0

--- a/lib/geomotion/version.rb
+++ b/lib/geomotion/version.rb
@@ -1,3 +1,3 @@
 module Geomotion
-  VERSION = "0.10.0"
+  VERSION = "0.11.0"
 end

--- a/spec/cg_affine_transform_spec.rb
+++ b/spec/cg_affine_transform_spec.rb
@@ -1,0 +1,204 @@
+describe "CGAffineTransform" do
+
+  describe "operations" do
+
+    it "should support ==" do
+      CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0).should == CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0)
+    end
+
+    it "should support +" do
+      (
+        CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0) \
+        +
+        CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10)
+      ).should == CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 10, ty: 10)
+    end
+
+    it "should support <<" do
+      (
+        CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0) \
+        <<
+        CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10)
+      ).should == CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 10, ty: 10)
+    end
+
+    it "should support -" do
+      (
+        CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0) \
+        -
+        CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10)
+      ).should == CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: -10, ty: -10)
+    end
+
+    it "subtracting itself should return identity (scale)" do
+      (
+        CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0) \
+        -
+        CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0)
+      ).should == CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 0, ty: 0)
+    end
+
+    it "subtracting itself should return identity (translate)" do
+      (
+        CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10) \
+        -
+        CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10)
+      ).should == CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 0, ty: 0)
+    end
+
+    it "subtracting itself should return identity (rotate)" do
+      (
+        CGAffineTransform.make(a: -1, b: 0, c: 0, d: -1, tx: 0, ty: 0) \
+        -
+        CGAffineTransform.make(a: -1, b: 0, c: 0, d: -1, tx: 0, ty: 0)
+      ).should == CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 0, ty: 0)
+    end
+
+    it "should support unary -" do
+      (- CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0)).should == CGAffineTransform.make(a: 0.5, b: 0, c: 0, d: 0.5, tx: 0, ty: 0)
+    end
+
+    it "should support unary +" do
+      (+ CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 0, ty: 0)).should == CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 0, ty: 0)
+    end
+
+  end
+
+  describe ".make" do
+
+    it "should work with options" do
+      transform = CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0)
+      transform.should == CGAffineTransformMake(2, 0, 0, 2, 0, 0)
+    end
+
+    it "should work with transform options (scale)" do
+      CGAffineTransform.make(scale: [2, 3]).should == CGAffineTransformMake(2, 0, 0, 3, 0, 0)
+    end
+
+    it "should work with transform options (translate)" do
+      CGAffineTransform.make(translate: [10, 20]).should == CGAffineTransformMake(1, 0, 0, 1, 10, 20)
+    end
+
+    it "should work with transform options (rotate)" do
+      transform = CGAffineTransform.make(rotate: Math::PI).to_a.map { |v| v.round(3) }
+      CGAffineTransform.new(*transform).should == CGAffineTransformMake(-1, 0, 0, -1, 0, 0)
+    end
+
+    it "should work with transform options (scale + translate)" do
+      CGAffineTransform.make(scale: [2, 3], translate: [10, 20]).should == CGAffineTransformMake(2, 0, 0, 3, 10, 20)
+    end
+
+    it "should work with transform options (scale + translate + rotation)" do
+      transform = CGAffineTransform.make(scale: [2, 3], rotate: Math::PI, translate: [10, 10]).to_a.map { |v| v.round(3) }
+      CGAffineTransform.new(*transform).should == CGAffineTransformMake(-2, 0, 0, -3, 10, 10)
+    end
+
+  end
+
+  describe "identity" do
+
+    it "should return the identity matrix" do
+      CGAffineTransformIsIdentity(CGAffineTransform.identity).should == true
+    end
+
+    it "identity? should return true for identity matrix" do
+      CGAffineTransform.identity.identity?.should == true
+    end
+
+    it "identity? should return false other matrices" do
+      CGAffineTransform.scale(2).identity?.should == false
+    end
+
+  end
+
+  describe ".rotate" do
+
+    it "should work as a factory" do
+      transform = CGAffineTransform.rotate(Math::PI).to_a.map { |v| v.round(3) }
+      CGAffineTransform.new(*transform).should == CGAffineTransformMake(-1, 0, 0, -1, 0, 0)
+    end
+
+    it "should work as an instance method" do
+      transform = CGAffineTransform.identity.rotate(Math::PI).to_a.map { |v| v.round(3) }
+      CGAffineTransform.new(*transform).should == CGAffineTransformMake(-1, 0, 0, -1, 0, 0)
+    end
+
+  end
+
+  describe ".scale" do
+
+    it "should work as a factory with one argument" do
+      CGAffineTransform.scale(2).should == CGAffineTransformMake(2, 0, 0, 2, 0, 0)
+    end
+
+    it "should work as a factory with two arguments" do
+      CGAffineTransform.scale(2, 3).should == CGAffineTransformMake(2, 0, 0, 3, 0, 0)
+    end
+
+    it "should work as a factory with one array" do
+      CGAffineTransform.scale([2, 3]).should == CGAffineTransformMake(2, 0, 0, 3, 0, 0)
+    end
+
+    it "should work as an instance method with one argument" do
+      CGAffineTransform.identity.scale(2).should == CGAffineTransformMake(2, 0, 0, 2, 0, 0)
+    end
+
+    it "should work as an instance method with two arguments" do
+      CGAffineTransform.identity.scale(2, 3).should == CGAffineTransformMake(2, 0, 0, 3, 0, 0)
+    end
+
+    it "should work as an instance method with one array" do
+      CGAffineTransform.identity.scale([2, 3]).should == CGAffineTransformMake(2, 0, 0, 3, 0, 0)
+    end
+
+  end
+
+  describe ".translate" do
+
+    it "should work as a factory with two arguments" do
+      CGAffineTransform.translate(10, 20).should == CGAffineTransformMake(1, 0, 0, 1, 10, 20)
+    end
+
+    it "should work as a factory with one array" do
+      CGAffineTransform.translate([10, 20]).should == CGAffineTransformMake(1, 0, 0, 1, 10, 20)
+    end
+
+    it "should work as an instance method with two arguments" do
+      CGAffineTransform.identity.translate(10, 20).should == CGAffineTransformMake(1, 0, 0, 1, 10, 20)
+    end
+
+    it "should work as an instance method with one array" do
+      CGAffineTransform.identity.translate([10, 20]).should == CGAffineTransformMake(1, 0, 0, 1, 10, 20)
+    end
+
+  end
+
+  describe "apply_to" do
+
+    before do
+      @transform = CGAffineTransform.make(a: 2, b: 0, c: 0, d: 3, tx: 10, ty: 20)
+    end
+
+    it "should work on a point" do
+      thing = CGPoint.new(0, 0)
+      @transform.apply_to(thing).should == CGPoint.new(10, 20)
+    end
+
+    it "should work on a size" do
+      thing = CGSize.new(10, 10)
+      @transform.apply_to(thing).should == CGSize.new(20, 30)
+    end
+
+    it "should work on a rect" do
+      thing = CGRect.new([0, 0], [10, 10])
+      @transform.apply_to(thing).should == CGRect.new([10, 20], [20, 30])
+    end
+
+    it "should not work on anything else" do
+      ->{ @transform.apply_to(1) }.should.raise
+      ->{ @transform.apply_to([0, 0]) }.should.raise
+    end
+
+  end
+
+end

--- a/spec/cg_affine_transform_spec.rb
+++ b/spec/cg_affine_transform_spec.rb
@@ -7,37 +7,37 @@ describe "CGAffineTransform" do
     end
 
     it "should support +" do
-      t1 = CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0) \
+      t1 = CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0)
       t2 = CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10)
       (t1 + t2).should == CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 10, ty: 10)
     end
 
     it "should support <<" do
-      t1 = CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0) \
+      t1 = CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0)
       t2 = CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10)
       (t1 << t2).should == CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 10, ty: 10)
     end
 
     it "should support -" do
-      t1 = CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0) \
+      t1 = CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0)
       t2 = CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10)
       (t1 - t2).should == CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: -10, ty: -10)
     end
 
     it "subtracting itself should return identity (scale)" do
-      t1 = CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0) \
+      t1 = CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0)
       t2 = CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0)
       (t1 - t2).should == CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 0, ty: 0)
     end
 
     it "subtracting itself should return identity (translate)" do
-      t1 = CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10) \
+      t1 = CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10)
       t2 = CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10)
       (t1 - t2).should == CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 0, ty: 0)
     end
 
     it "subtracting itself should return identity (rotate)" do
-      t1 = CGAffineTransform.make(a: -1, b: 0, c: 0, d: -1, tx: 0, ty: 0) \
+      t1 = CGAffineTransform.make(a: -1, b: 0, c: 0, d: -1, tx: 0, ty: 0)
       t2 = CGAffineTransform.make(a: -1, b: 0, c: 0, d: -1, tx: 0, ty: 0)
       (t1 - t2).should == CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 0, ty: 0)
     end

--- a/spec/cg_affine_transform_spec.rb
+++ b/spec/cg_affine_transform_spec.rb
@@ -7,51 +7,39 @@ describe "CGAffineTransform" do
     end
 
     it "should support +" do
-      (
-        CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0) \
-        +
-        CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10)
-      ).should == CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 10, ty: 10)
+      t1 = CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0) \
+      t2 = CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10)
+      (t1 + t2).should == CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 10, ty: 10)
     end
 
     it "should support <<" do
-      (
-        CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0) \
-        <<
-        CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10)
-      ).should == CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 10, ty: 10)
+      t1 = CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0) \
+      t2 = CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10)
+      (t1 << t2).should == CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 10, ty: 10)
     end
 
     it "should support -" do
-      (
-        CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0) \
-        -
-        CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10)
-      ).should == CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: -10, ty: -10)
+      t1 = CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0) \
+      t2 = CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10)
+      (t1 - t2).should == CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: -10, ty: -10)
     end
 
     it "subtracting itself should return identity (scale)" do
-      (
-        CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0) \
-        -
-        CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0)
-      ).should == CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 0, ty: 0)
+      t1 = CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0) \
+      t2 = CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0)
+      (t1 - t2).should == CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 0, ty: 0)
     end
 
     it "subtracting itself should return identity (translate)" do
-      (
-        CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10) \
-        -
-        CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10)
-      ).should == CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 0, ty: 0)
+      t1 = CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10) \
+      t2 = CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10)
+      (t1 - t2).should == CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 0, ty: 0)
     end
 
     it "subtracting itself should return identity (rotate)" do
-      (
-        CGAffineTransform.make(a: -1, b: 0, c: 0, d: -1, tx: 0, ty: 0) \
-        -
-        CGAffineTransform.make(a: -1, b: 0, c: 0, d: -1, tx: 0, ty: 0)
-      ).should == CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 0, ty: 0)
+      t1 = CGAffineTransform.make(a: -1, b: 0, c: 0, d: -1, tx: 0, ty: 0) \
+      t2 = CGAffineTransform.make(a: -1, b: 0, c: 0, d: -1, tx: 0, ty: 0)
+      (t1 - t2).should == CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 0, ty: 0)
     end
 
     it "should support unary -" do
@@ -65,6 +53,11 @@ describe "CGAffineTransform" do
   end
 
   describe ".make" do
+
+    it "should work with no arguments" do
+      transform = CGAffineTransform.make
+      transform.should == CGAffineTransformMake(1, 0, 0, 1, 0, 0)
+    end
 
     it "should work with options" do
       transform = CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0)
@@ -106,7 +99,7 @@ describe "CGAffineTransform" do
     end
 
     it "identity? should return false other matrices" do
-      CGAffineTransform.scale(2).identity?.should == false
+      CGAffineTransform.new(2, 0, 0, 2, 0, 0).identity?.should == false
     end
 
   end
@@ -197,6 +190,21 @@ describe "CGAffineTransform" do
     it "should not work on anything else" do
       ->{ @transform.apply_to(1) }.should.raise
       ->{ @transform.apply_to([0, 0]) }.should.raise
+    end
+
+  end
+
+  describe "other methods" do
+
+    it "should support concat" do
+      t1 = CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0)
+      t2 = CGAffineTransform.make(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10)
+      t1.concat(t2).should == CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 10, ty: 10)
+    end
+
+    it "should support invert" do
+      t1 = CGAffineTransform.make(a: 2, b: 0, c: 0, d: 2, tx: 0, ty: 0)
+      t1.invert.should == CGAffineTransform.make(a: 0.5, b: 0, c: 0, d: 0.5, tx: 0, ty: 0)
     end
 
   end

--- a/spec/cg_rect_spec.rb
+++ b/spec/cg_rect_spec.rb
@@ -8,9 +8,16 @@ describe "CGRect" do
       CGRectEqualToRect(@rect, CGRectMake(10, 100, 50, 20)).should == true
     end
 
-    it "should work with nested options" do
+    it "should work with nested options (CGPoint, CGSize)" do
       CGRectEqualToRect(
         CGRect.make(origin: CGPointMake(10, 100), size: CGSizeMake(50,20)),
+        CGRectMake(10, 100, 50, 20)
+      ).should == true
+    end
+
+    it "should work with nested options (Arrays)" do
+      CGRectEqualToRect(
+        CGRect.make(origin: [10, 100], size: [50,20]),
         CGRectMake(10, 100, 50, 20)
       ).should == true
     end


### PR DESCRIPTION
CATransform3D coming soon, but this one is the smaller sibling, so tackled it first.

Version bump to 0.11.0 (should CATransform3D bump to 0.12.0 or 0.11.1?)

Also, gave `CGRect.make(point:, size:)` support for "CGPoint/CGSize-like" arrays.
