### PR TITLE
Pull requests usually come in pairs, right?

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    geomotion (0.13.0)
+    geomotion (0.13.1)
 
 GEM
   remote: http://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -191,20 +191,27 @@ frame.bottom_right(true)  # => [20, 20]
 
 #### The great and powerful `apply` method
 
+Most of the frame-manipulation methods delegate to the `apply` method.  You can
+use this method to perform batch changes.
+
+```ruby
+frame = view.frame.apply(left: 10, y: 0, wider: 50, grow_height: 10)
+```
+
 All of the methods that return a new frame (`left, shrink, below` and friends)
 also accept a hash in which you can apply more changes.  You can accomplish the
 same thing using method chaining; this is an implementation detail that might
-also clean your code up by grouping changes.  And, of course, it can be used on
-its own as well.
+also clean your code up by grouping changes.
 
 ```ruby
 frame = CGRect.make(x: 10, y: 10, width:10, height: 10)
 frame.beside.width(20).down(10).height(20)
 # => [[20, 20], [20, 20]]
-# or, using the options hash
-frame.beside(width: 20, down: 10, height: 20)
 
-# there are some changes that don't have a corresponding method:
+# using the options hash / apply method
+frame.beside(width: 20, down: 10, height: 20)
+# => [[20, 20], [20, 20]]
+
 frame.below(grow_width: 10, grow_up: 5)
 # => [[0, 15], [40, 25]]
 ```

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -210,65 +210,105 @@ class CGRect
   end
 
   # modified rects
-  def left(dist = 0, options={})
+  def left(dist=nil, options={})
+    if dist.nil?
+      NSLog("Using the default value of `0` in `CGRect#left` is deprecated.")
+      dist = 0
+    end
+    raise "You must specify an amount in `CGRect#left`" unless dist.is_a?(Numeric)
+
     options[:left] = dist
     self.apply(options)
   end
 
-  def right(dist = 0, options={})
+  def right(dist=nil, options={})
+    if dist.nil?
+      NSLog("Using the default value of `0` in `CGRect#right` is deprecated.")
+      dist = 0
+    end
+    raise "You must specify an amount in `CGRect#right`" unless dist.is_a?(Numeric)
+
     options[:right] = dist
     self.apply(options)
   end
 
-  def up(dist = 0, options={})
+  def up(dist=nil, options={})
+    if dist.nil?
+      NSLog("Using the default value of `0` in `CGRect#up` is deprecated.")
+      dist = 0
+    end
+    raise "You must specify an amount in `CGRect#up`" unless dist.is_a?(Numeric)
+
     options[:up] = dist
     self.apply(options)
   end
 
-  def down(dist = 0, options={})
+  def down(dist=nil, options={})
+    if dist.nil?
+      NSLog("Using the default value of `0` in `CGRect#down` is deprecated.")
+      dist = 0
+    end
+    raise "You must specify an amount in `CGRect#down`" unless dist.is_a?(Numeric)
+
     options[:down] = dist
     self.apply(options)
   end
 
   def wider(dist, options={})
+    raise "You must specify an amount in `CGRect#wider`" unless dist.is_a?(Numeric)
+
     options[:wider] = dist
     self.apply(options)
   end
 
   def thinner(dist, options={})
+    raise "You must specify an amount in `CGRect#thinner`" unless dist.is_a?(Numeric)
+
     options[:thinner] = dist
     self.apply(options)
   end
 
   def taller(dist, options={})
+    raise "You must specify an amount in `CGRect#taller`" unless dist.is_a?(Numeric)
+
     options[:taller] = dist
     self.apply(options)
   end
 
   def shorter(dist, options={})
+    raise "You must specify an amount in `CGRect#shorter`" unless dist.is_a?(Numeric)
+
     options[:shorter] = dist
     self.apply(options)
   end
 
   # adjacent rects
   def above(margin = 0, options={})
+    margin, options = 0, margin if margin.is_a?(NSDictionary)
+
     height = options[:height] || self.size.height
     options[:up] = height + margin
     self.apply(options)
   end
 
   def below(margin = 0, options={})
+    margin, options = 0, margin if margin.is_a?(NSDictionary)
+
     options[:down] = self.size.height + margin
     self.apply(options)
   end
 
   def before(margin = 0, options={})
+    margin, options = 0, margin if margin.is_a?(NSDictionary)
+
     width = options[:width] || self.size.width
     options[:left] = width + margin
     self.apply(options)
   end
 
   def beside(margin = 0, options={})
+    margin, options = 0, margin if margin.is_a?(NSDictionary)
+
     options[:right] = self.size.width + margin
     self.apply(options)
   end

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -191,15 +191,15 @@ class CGRect
         rect.size.width -= value
         rect.origin.x += value
       when :grow_width
-        rect = rect.grow([value, 0])
+        rect = rect.grow_width(value)
       when :grow_height
-        rect = rect.grow([0, value])
+        rect = rect.grow_height(value)
       when :shrink
         rect = rect.shrink(value)
       when :shrink_width
-        rect = rect.shrink([value, 0])
+        rect = rect.shrink_width(value)
       when :shrink_height
-        rect = rect.shrink([0, value])
+        rect = rect.shrink_height(value)
       when :offset
         rect = rect.offset(value)
       else
@@ -395,6 +395,30 @@ public
     return rect
   end
 
+  alias grow_right wider
+  def grow_left(amount, options=nil)
+    raise "You must specify an amount in `CGRect#grow_left`" unless amount.is_a?(Numeric)
+
+    options[:grow_left] = amount
+    self.apply(options)
+  end
+
+  alias grow_down taller
+  def grow_up(amount, options=nil)
+    raise "You must specify an amount in `CGRect#grow_up`" unless amount.is_a?(Numeric)
+
+    options[:grow_up] = amount
+    self.apply(options)
+  end
+
+  def grow_width(amount, options=nil)
+    return self.grow([amount, 0], options)
+  end
+
+  def grow_height(amount, options=nil)
+    return self.grow([0, amount], options)
+  end
+
   def shrink(size, options=nil)
     if size.is_a? Numeric
       size = CGSize.new(size, size)
@@ -404,6 +428,30 @@ public
       return rect.apply(options)
     end
     return rect
+  end
+
+  alias shrink_left thinner
+  def shrink_right(amount, options={})
+    raise "You must specify an amount in `CGRect#shrink_right`" unless amount.is_a?(Numeric)
+
+    options[:shrink_right] = amount
+    self.apply(options)
+  end
+
+  alias shrink_up shorter
+  def shrink_down(amount, options={})
+    raise "You must specify an amount in `CGRect#shrink_down`" unless amount.is_a?(Numeric)
+
+    options[:shrink_down] = amount
+    self.apply(options)
+  end
+
+  def shrink_width(amount, options={})
+    return self.shrink([amount, 0], options)
+  end
+
+  def shrink_height(amount, options={})
+    return self.shrink([0, amount], options)
   end
 
   def empty?

--- a/lib/geomotion/version.rb
+++ b/lib/geomotion/version.rb
@@ -1,3 +1,3 @@
 module Geomotion
-  VERSION = "0.13.0"
+  VERSION = "0.13.1"
 end

--- a/spec/cg_rect_spec.rb
+++ b/spec/cg_rect_spec.rb
@@ -711,6 +711,50 @@ describe "CGRect" do
     end
   end
 
+  describe "#grow_left" do
+    # @rect = CGRect.make(x: 10, y: 100, width: 50, height: 20)
+    it "should work" do
+      rect = @rect.grow_left(10)
+      rect.should == CGRectMake(0, 100, 60, 20)
+    end
+  end
+
+  describe "#grow_right" do
+    it "should work" do
+      rect = @rect.grow_right(10)
+      rect.should == CGRectMake(10, 100, 60, 20)
+    end
+  end
+
+  describe "#grow_up" do
+    it "should work" do
+      rect = @rect.grow_up(10)
+      rect.should == CGRectMake(10, 90, 50, 30)
+    end
+  end
+
+  describe "#grow_down" do
+    it "should work" do
+      rect = @rect.grow_down(10)
+      rect.should == CGRectMake(10, 100, 50, 30)
+    end
+  end
+
+  describe "#grow_width" do
+    # @rect = CGRect.make(x: 10, y: 100, width: 50, height: 20)
+    it "should work" do
+      rect = @rect.grow_width(10)
+      rect.should == CGRectMake(0, 100, 70, 20)
+    end
+  end
+
+  describe "#grow_height" do
+    it "should work" do
+      rect = @rect.grow_height(10)
+      rect.should == CGRectMake(10, 90, 50, 40)
+    end
+  end
+
   describe "#shrink" do
     it "should work with Numeric" do
       rect = @rect.shrink(10)
@@ -725,6 +769,49 @@ describe "CGRect" do
     it "should work with Array" do
       rect = @rect.shrink([20, 10])
       rect.should == CGRectMake(30, 110, 10, 0)
+    end
+  end
+
+  describe "#shrink_left" do
+    it "should work" do
+      rect = @rect.shrink_left(10)
+      rect.should == CGRectMake(10, 100, 40, 20)
+    end
+  end
+
+  describe "#shrink_right" do
+    it "should work" do
+      rect = @rect.shrink_right(10)
+      rect.should == CGRectMake(20, 100, 40, 20)
+    end
+  end
+
+  describe "#shrink_up" do
+    it "should work" do
+      rect = @rect.shrink_up(10)
+      rect.should == CGRectMake(10, 100, 50, 10)
+    end
+  end
+
+  describe "#shrink_down" do
+    it "should work" do
+      rect = @rect.shrink_down(10)
+      rect.should == CGRectMake(10, 110, 50, 10)
+    end
+  end
+
+  describe "#shrink_width" do
+    # @rect = CGRect.make(x: 10, y: 100, width: 50, height: 20)
+    it "should work" do
+      rect = @rect.shrink_width(10)
+      rect.should == CGRectMake(20, 100, 30, 20)
+    end
+  end
+
+  describe "#shrink_height" do
+    it "should work" do
+      rect = @rect.shrink_height(10)
+      rect.should == CGRectMake(10, 110, 50, 0)
     end
   end
 

--- a/spec/cg_rect_spec.rb
+++ b/spec/cg_rect_spec.rb
@@ -288,9 +288,14 @@ describe "CGRect" do
 
   describe "#left" do
     it "works" do
-      rect = CGRect.empty
-      rect = rect.left(20)
+      rect = CGRect.empty.left(20)
       rect.origin.x.should == -20
+    end
+
+    it "works with options" do
+      rect = CGRect.empty.left(20, width: 20)
+      rect.origin.x.should == -20
+      rect.size.width.should == 20
     end
   end
 
@@ -299,12 +304,24 @@ describe "CGRect" do
       rect = CGRect.empty.right(20)
       rect.origin.x.should == 20
     end
+
+    it "works with options" do
+      rect = CGRect.empty.right(20, width: 20)
+      rect.origin.x.should == 20
+      rect.size.width.should == 20
+    end
   end
 
   describe "#up" do
     it "works" do
       rect = CGRect.empty.up(20)
       rect.origin.y.should == -20
+    end
+
+    it "works with options" do
+      rect = CGRect.empty.up(20, height: 20)
+      rect.origin.y.should == -20
+      rect.size.height.should == 20
     end
   end
 
@@ -313,6 +330,12 @@ describe "CGRect" do
       rect = CGRect.empty.down(20)
       rect.origin.y.should == 20
     end
+
+    it "works with options" do
+      rect = CGRect.empty.down(20, height: 20)
+      rect.origin.y.should == 20
+      rect.size.height.should == 20
+    end
   end
 
   describe "#wider" do
@@ -320,106 +343,154 @@ describe "CGRect" do
       rect = CGRect.empty.wider(20)
       rect.size.width.should == 20
     end
+
+    it "works with options" do
+      rect = CGRect.empty.wider(20, height: 20)
+      rect.size.width.should == 20
+      rect.size.height.should == 20
+    end
   end
 
   describe "#thinner" do
     it "works" do
-      rect = CGRect.empty.thinner(20)
-      rect.size.width.should == -20
+      rect = CGRect.make(width: 20).thinner(10)
+      rect.size.width.should == 10
+    end
+
+    it "works with options" do
+      rect = CGRect.make(width: 20).thinner(10, height: 20)
+      rect.size.width.should == 10
+      rect.size.height.should == 20
     end
   end
 
   describe "#taller" do
     it "works" do
-      rect = CGRect.empty.taller(20)
-      rect.size.height.should == 20
+      rect = CGRect.make(height: 20).taller(20)
+      rect.size.height.should == 40
+    end
+
+    it "works with options" do
+      rect = CGRect.make(height: 20).taller(20, width: 20)
+      rect.size.width.should == 20
+      rect.size.height.should == 40
     end
   end
 
   describe "#shorter" do
     it "works" do
-      rect = CGRect.empty.shorter(20)
-      rect.size.height.should == -20
+      rect = CGRect.make(height: 20).shorter(10)
+      rect.size.height.should == 10
+    end
+
+    it "works with options" do
+      rect = CGRect.make(height: 20).shorter(10, width: 20)
+      rect.size.width.should == 20
+      rect.size.height.should == 10
     end
   end
 
   describe "#above" do
+    it "works without margins" do
+      rect = CGRect.make(height: 50).above
+      rect.origin.y.should == -50
+      rect.size.height.should == 50
+    end
+
     it "works with margins" do
       rect = CGRect.make(height: 50).above(20)
       rect.origin.y.should == -70
       rect.size.height.should == 50
     end
 
-    it "works with height" do
+    it "works with options" do
       rect = CGRect.make(height: 50).above(20, height: 10)
       rect.origin.y.should == -30
       rect.size.height.should == 10
     end
 
-    it "works without margins" do
-      rect = CGRect.make(height: 50).above
-      rect.origin.y.should == -50
-      rect.size.height.should == 50
+    it "works with options and no margin" do
+      rect = CGRect.make(height: 50).above(height: 10)
+      rect.origin.y.should == -10
+      rect.size.height.should == 10
     end
   end
 
   describe "#below" do
+    it "works without margins" do
+      rect = CGRect.make(height: 50).below
+      rect.origin.y.should == 50
+      rect.size.height.should == 50
+    end
+
     it "works with margins" do
       rect = CGRect.make(height: 50).below(20)
       rect.origin.y.should == 70
       rect.size.height.should == 50
     end
 
-    it "works with height" do
+    it "works with options" do
       rect = CGRect.make(height: 50).below(20, height: 10)
       rect.origin.y.should == 70
       rect.size.height.should == 10
     end
 
-    it "works without margins" do
-      rect = CGRect.make(height: 50).below
+    it "works with options and no margin" do
+      rect = CGRect.make(height: 50).below(height: 10)
       rect.origin.y.should == 50
-      rect.size.height.should == 50
+      rect.size.height.should == 10
     end
   end
 
   describe "#before" do
+    it "works without margins" do
+      rect = CGRect.make(width: 50).before
+      rect.origin.x.should == -50
+      rect.size.width.should == 50
+    end
+
     it "works with margins" do
       rect = CGRect.make(width: 50).before(20)
       rect.origin.x.should == -70
       rect.size.width.should == 50
     end
 
-    it "works with width" do
+    it "works with options" do
       rect = CGRect.make(width: 50).before(20, width: 10)
       rect.origin.x.should == -30
       rect.size.width.should == 10
     end
 
-    it "works without margins" do
-      rect = CGRect.make(width: 50).before
-      rect.origin.x.should == -50
-      rect.size.width.should == 50
+    it "works with options and no margin" do
+      rect = CGRect.make(width: 50).before(width: 10)
+      rect.origin.x.should == -10
+      rect.size.width.should == 10
     end
   end
 
   describe "#beside" do
+    it "works without margins" do
+      rect = CGRect.make(width: 50).beside
+      rect.origin.x.should == 50
+      rect.size.width.should == 50
+    end
+
     it "works with margins" do
       rect = CGRect.make(width: 50).beside(20)
       rect.origin.x.should == 70
       rect.size.width.should == 50
     end
 
-    it "works with width" do
+    it "works with options" do
       rect = CGRect.make(width: 50).beside(20, width: 10)
       rect.origin.x.should == 70
       rect.size.width.should == 10
     end
 
-    it "works without margins" do
-      rect = CGRect.make(width: 50).beside
+    it "works with options and no margin" do
+      rect = CGRect.make(width: 50).beside(width: 10)
       rect.origin.x.should == 50
-      rect.size.width.should == 50
+      rect.size.width.should == 10
     end
   end
 


### PR DESCRIPTION
A few house keeping things; I added methods for the `grow_up`, `shrink_width` and so on that were in `apply`, for consistency.

I'd like to deprecate the optional `dist` argument in `up,down,left,right`.  The default value of `0` is silly (`frame = other_frame.left => frame == other_frame ?`).  Other than that, added some exceptions if required arguments are missing.
