### PR TITLE
Adds `from_{left,right,top,bottom}` methods, and some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ another_way = CGRect.make(origin: CGPoint, size: CGSize)
 [rect.x, rect.y, rect.width, rect.height]
 => [10, 100, 50, 20]
 
+rect_zero = CGRect.zero
 rect_zero = CGRect.empty
 => CGRect(0, 0, 0, 0)
 rect_zero.empty?

--- a/lib/geomotion/cg_point.rb
+++ b/lib/geomotion/cg_point.rb
@@ -57,6 +57,8 @@ class CGPoint
       return self.rect_of_size(other)
     when CGPoint
       return CGPoint.new(self.x + other.x, self.y + other.y)
+    when CGRect
+      return CGPoint.new(self.x + other.origin.x, self.y + other.origin.y).rect_of_size(other.size)
     end
   end
 

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -343,7 +343,7 @@ class CGRect
     options[:x] = margin
     options[:y] ||= 0
     options[:height] ||= self.size.height
-    self.apply(options)
+    cgrect_offset(options.delete(:absolute)) + self.apply(options)
   end
 
   # Create a rect inside the receiver, on the right side.  If `margin` is
@@ -355,7 +355,7 @@ class CGRect
     options[:x] = self.size.width - width - margin
     options[:y] ||= 0
     options[:height] ||= self.size.height
-    self.apply(options)
+    cgrect_offset(options.delete(:absolute)) + self.apply(options)
   end
 
   # Create a rect inside the receiver, on the top side.  If `margin` is
@@ -367,7 +367,7 @@ class CGRect
     options[:x] ||= 0
     options[:y] = margin
     options[:width] ||= self.size.width
-    self.apply(options)
+    cgrect_offset(options.delete(:absolute)) + self.apply(options)
   end
 
   # Create a rect inside the receiver, on the bottom side.  If `margin` is
@@ -379,7 +379,7 @@ class CGRect
     options[:x] ||= 0
     options[:y] = self.size.height - height - margin
     options[:width] ||= self.size.width
-    self.apply(options)
+    cgrect_offset(options.delete(:absolute)) + self.apply(options)
   end
 
   # positions

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -332,6 +332,56 @@ class CGRect
     self.apply(options)
   end
 
+  # these methods create a rect INSIDE the receiver
+
+  # Create a rect inside the receiver, on the left side.  If `margin` is
+  # supplied, the rect will be moved that number of points to the right.
+  def from_left(options={})
+    width = options[:width]
+    margin = options.delete(:margin) || 0
+    raise "You must specify a width in `CGRect#from_left`" unless width
+    options[:x] = margin
+    options[:y] ||= 0
+    options[:height] ||= self.size.height
+    self.apply(options)
+  end
+
+  # Create a rect inside the receiver, on the right side.  If `margin` is
+  # supplied, the rect will be moved that number of points to the left.
+  def from_right(options={})
+    width = options[:width]
+    margin = options.delete(:margin) || 0
+    raise "You must specify a width in `CGRect#from_right`" unless width
+    options[:x] = self.size.width - width - margin
+    options[:y] ||= 0
+    options[:height] ||= self.size.height
+    self.apply(options)
+  end
+
+  # Create a rect inside the receiver, on the top side.  If `margin` is
+  # supplied, the rect will be moved that number of points down.
+  def from_top(options={})
+    height = options[:height]
+    margin = options.delete(:margin) || 0
+    raise "You must specify a height in `CGRect#from_top`" unless height
+    options[:x] ||= 0
+    options[:y] = margin
+    options[:width] ||= self.size.width
+    self.apply(options)
+  end
+
+  # Create a rect inside the receiver, on the bottom side.  If `margin` is
+  # supplied, the rect will be moved that number of points up.
+  def from_bottom(options={})
+    height = options[:height]
+    margin = options.delete(:margin) || 0
+    raise "You must specify a height in `CGRect#from_bottom`" unless height
+    options[:x] ||= 0
+    options[:y] = self.size.height - height - margin
+    options[:width] ||= self.size.width
+    self.apply(options)
+  end
+
   # positions
 private
   def cgrect_offset(absolute)

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -236,8 +236,9 @@ class CGRect
     end
     raise "You must specify an amount in `CGRect#left`" unless dist.is_a?(Numeric)
 
-    options[:left] = dist
-    self.apply(options)
+    self.apply({
+      left: dist
+      }.merge(options))
   end
 
   def right(dist=nil, options={})
@@ -247,8 +248,9 @@ class CGRect
     end
     raise "You must specify an amount in `CGRect#right`" unless dist.is_a?(Numeric)
 
-    options[:right] = dist
-    self.apply(options)
+    self.apply({
+      right: dist
+      }.merge(options))
   end
 
   def up(dist=nil, options={})
@@ -258,8 +260,9 @@ class CGRect
     end
     raise "You must specify an amount in `CGRect#up`" unless dist.is_a?(Numeric)
 
-    options[:up] = dist
-    self.apply(options)
+    self.apply({
+      up: dist
+      }.merge(options))
   end
 
   def down(dist=nil, options={})
@@ -269,36 +272,41 @@ class CGRect
     end
     raise "You must specify an amount in `CGRect#down`" unless dist.is_a?(Numeric)
 
-    options[:down] = dist
-    self.apply(options)
+    self.apply({
+      down: dist
+      }.merge(options))
   end
 
   def wider(dist, options={})
     raise "You must specify an amount in `CGRect#wider`" unless dist.is_a?(Numeric)
 
-    options[:wider] = dist
-    self.apply(options)
+    self.apply({
+      wider: dist
+      }.merge(options))
   end
 
   def thinner(dist, options={})
     raise "You must specify an amount in `CGRect#thinner`" unless dist.is_a?(Numeric)
 
-    options[:thinner] = dist
-    self.apply(options)
+    self.apply({
+      thinner: dist
+      }.merge(options))
   end
 
   def taller(dist, options={})
     raise "You must specify an amount in `CGRect#taller`" unless dist.is_a?(Numeric)
 
-    options[:taller] = dist
-    self.apply(options)
+    self.apply({
+      taller: dist
+      }.merge(options))
   end
 
   def shorter(dist, options={})
     raise "You must specify an amount in `CGRect#shorter`" unless dist.is_a?(Numeric)
 
-    options[:shorter] = dist
-    self.apply(options)
+    self.apply({
+      shorter: dist
+      }.merge(options))
   end
 
   # adjacent rects
@@ -306,30 +314,34 @@ class CGRect
     margin, options = 0, margin if margin.is_a?(NSDictionary)
 
     height = options[:height] || self.size.height
-    options[:up] = height + margin
-    self.apply(options)
+    self.apply({
+      up: height + margin
+      }.merge(options))
   end
 
   def below(margin = 0, options={})
     margin, options = 0, margin if margin.is_a?(NSDictionary)
 
-    options[:down] = self.size.height + margin
-    self.apply(options)
+    self.apply({
+      down: self.size.height + margin
+      }.merge(options))
   end
 
   def before(margin = 0, options={})
     margin, options = 0, margin if margin.is_a?(NSDictionary)
 
     width = options[:width] || self.size.width
-    options[:left] = width + margin
-    self.apply(options)
+    self.apply({
+      left: width + margin
+      }.merge(options))
   end
 
   def beside(margin = 0, options={})
     margin, options = 0, margin if margin.is_a?(NSDictionary)
 
-    options[:right] = self.size.width + margin
-    self.apply(options)
+    self.apply({
+      right: self.size.width + margin
+      }.merge(options))
   end
 
   # these methods create a rect INSIDE the receiver
@@ -340,10 +352,13 @@ class CGRect
     width = options[:width]
     margin = options.delete(:margin) || 0
     raise "You must specify a width in `CGRect#from_left`" unless width
-    options[:x] = margin
-    options[:y] ||= 0
-    options[:height] ||= self.size.height
-    cgrect_offset(options.delete(:absolute)) + self.apply(options)
+    offset = cgrect_offset(options.delete(:absolute))
+    self.apply({
+      x: offset.x + margin,
+      y: offset.y,
+      height: self.size.height,
+      width: width
+      }.merge(options))
   end
 
   # Create a rect inside the receiver, on the right side.  If `margin` is
@@ -352,10 +367,13 @@ class CGRect
     width = options[:width]
     margin = options.delete(:margin) || 0
     raise "You must specify a width in `CGRect#from_right`" unless width
-    options[:x] = self.size.width - width - margin
-    options[:y] ||= 0
-    options[:height] ||= self.size.height
-    cgrect_offset(options.delete(:absolute)) + self.apply(options)
+    offset = cgrect_offset(options.delete(:absolute))
+    self.apply({
+      x: offset.x + self.size.width - width - margin,
+      y: offset.y,
+      height: self.size.height,
+      width: width
+      }.merge(options))
   end
 
   # Create a rect inside the receiver, on the top side.  If `margin` is
@@ -364,10 +382,13 @@ class CGRect
     height = options[:height]
     margin = options.delete(:margin) || 0
     raise "You must specify a height in `CGRect#from_top`" unless height
-    options[:x] ||= 0
-    options[:y] = margin
-    options[:width] ||= self.size.width
-    cgrect_offset(options.delete(:absolute)) + self.apply(options)
+    offset = cgrect_offset(options.delete(:absolute))
+    self.apply({
+      x: offset.x,
+      y: offset.y + margin,
+      width: self.size.width,
+      height: height
+      }.merge(options))
   end
 
   # Create a rect inside the receiver, on the bottom side.  If `margin` is
@@ -376,10 +397,13 @@ class CGRect
     height = options[:height]
     margin = options.delete(:margin) || 0
     raise "You must specify a height in `CGRect#from_bottom`" unless height
-    options[:x] ||= 0
-    options[:y] = self.size.height - height - margin
-    options[:width] ||= self.size.width
-    cgrect_offset(options.delete(:absolute)) + self.apply(options)
+    offset = cgrect_offset(options.delete(:absolute))
+    self.apply({
+      x: offset.x,
+      y: offset.y + self.size.height - height - margin,
+      width: self.size.width,
+      height: height
+      }.merge(options))
   end
 
   # positions
@@ -508,16 +532,18 @@ public
   def grow_left(amount, options={})
     raise "You must specify an amount in `CGRect#grow_left`" unless amount.is_a?(Numeric)
 
-    options[:grow_left] = amount
-    self.apply(options)
+    self.apply({
+      grow_left: amount
+      }.merge(options))
   end
 
   alias grow_down taller
   def grow_up(amount, options={})
     raise "You must specify an amount in `CGRect#grow_up`" unless amount.is_a?(Numeric)
 
-    options[:grow_up] = amount
-    self.apply(options)
+    self.apply({
+      grow_up: amount
+      }.merge(options))
   end
 
   def grow_width(amount, options={})
@@ -543,16 +569,18 @@ public
   def shrink_right(amount, options={})
     raise "You must specify an amount in `CGRect#shrink_right`" unless amount.is_a?(Numeric)
 
-    options[:shrink_right] = amount
-    self.apply(options)
+    self.apply({
+      shrink_right: amount
+      }.merge(options))
   end
 
   alias shrink_up shorter
   def shrink_down(amount, options={})
     raise "You must specify an amount in `CGRect#shrink_down`" unless amount.is_a?(Numeric)
 
-    options[:shrink_down] = amount
-    self.apply(options)
+    self.apply({
+      shrink_down: amount
+      }.merge(options))
   end
 
   def shrink_width(amount, options={})

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -1,76 +1,79 @@
 class CGRect
 
-  # CGRect.make  # default rect: {origin: {x: 0, y: 0}, size: {width:0, height:0}}
-  #              # aka CGRectZero
-  # CGRect.make(x: 10, y: 30)  # default size: [0, 0]
-  # CGRect.make(x: 10, y: 30, width:100, height: 20)
-  #
-  # point = CGPoint.make(x: 10, y: 30)
-  # size = CGSize.make(width: 100, height: 20)
-  # CGRect.make(origin: point, size: size)
-  def self.make(options = {})
-    if options[:origin]
-      x = options[:origin][0]
-      y = options[:origin][1]
-    else
-      x = options[:x] || 0
-      y = options[:y] || 0
-    end
-    if options[:size]
-      w = options[:size][0]
-      h = options[:size][1]
-    else
-      w = options[:width] || 0
-      h = options[:height] || 0
-    end
-    self.new([x, y], [w, h])
-  end
-
-  def self.empty
-    # Don't just return CGRectZero; can be mutated
-    CGRectZero.dup
-  end
-
-  def self.null
-    # Don't just return CGRectNull; can be mutated
-    CGRectNull.dup
-  end
-
-  def self.infinite
-    # This actually returns the not-very-infinite value of:
-    # [[-1.7014114289565e+38, -1.7014114289565e+38], [3.402822857913e+38, 3.402822857913e+38]]
-    # originally this method returned [[-Infinity, -Infinity], [Infinity, Infinity]],
-    # but that rect ended up returning `false` for any point in the method
-    # CGRect.infinite.contains?(point).  CGRectInfinite returns `true` for any
-    # (sensible) point, so we'll go with that instead
-    CGRectInfinite.dup
-  end
-
-  # OPTIONS: [:above, :below, :left_of, :right_of, :margins]
-  #   :margins is array of [top, right, bottom, left]
-  # EX CGRect.layout(rect1, above: rect2, left_of: rect3, margins: [0, 10, 20, 0])
-  def self.layout(rect1, options)
-    if options.empty?
-      p "No options provided in #{self.class}.layout"
-      return rect1
+  class << self
+    # CGRect.make  # default rect: {origin: {x: 0, y: 0}, size: {width:0, height:0}}
+    #              # aka CGRectZero
+    # CGRect.make(x: 10, y: 30)  # default size: [0, 0]
+    # CGRect.make(x: 10, y: 30, width:100, height: 20)
+    #
+    # point = CGPoint.make(x: 10, y: 30)
+    # size = CGSize.make(width: 100, height: 20)
+    # CGRect.make(origin: point, size: size)
+    def make(options = {})
+      if options[:origin]
+        x = options[:origin][0]
+        y = options[:origin][1]
+      else
+        x = options[:x] || 0
+        y = options[:y] || 0
+      end
+      if options[:size]
+        w = options[:size][0]
+        h = options[:size][1]
+      else
+        w = options[:width] || 0
+        h = options[:height] || 0
+      end
+      self.new([x, y], [w, h])
     end
 
-    rect = self.new
-    rect.size = rect1.size
+    def zero
+      CGRect.new([0, 0], [0, 0])
+    end
+    alias empty zero
 
-    options[:margins] ||= []
-    margins = {}
-    [:top, :right, :bottom, :left].each_with_index do |margin, index|
-      margins[margin] = options[:margins][index] || 0
+    def null
+      # Don't just return CGRectNull; can be mutated
+      CGRect.new([Float::INFINITY, Float::INFINITY], [0, 0])
     end
 
-    rect.y = options[:above].up(rect.height + margins[:bottom]).y if options[:above]
-    rect.y = options[:below].below(margins[:top]).y if options[:below]
+    def infinite
+      # This actually returns the not-very-infinite value of:
+      # [[-1.7014114289565e+38, -1.7014114289565e+38], [3.402822857913e+38, 3.402822857913e+38]]
+      # originally this method returned [[-Infinity, -Infinity], [Infinity, Infinity]],
+      # but that rect ended up returning `false` for any point in the method
+      # CGRect.infinite.contains?(point).  CGRectInfinite returns `true` for any
+      # (sensible) point, so we'll go with that instead
+      CGRectInfinite.dup
+    end
 
-    rect.x = options[:left_of].left(rect.width + margins[:right]).x if options[:left_of]
-    rect.x = options[:right_of].beside(margins[:left]).x if options[:right_of]
+    # OPTIONS: [:above, :below, :left_of, :right_of, :margins]
+    #   :margins is array of [top, right, bottom, left]
+    # EX CGRect.layout(rect1, above: rect2, left_of: rect3, margins: [0, 10, 20, 0])
+    def layout(rect1, options)
+      if options.empty?
+        p "No options provided in #{self.class}.layout"
+        return rect1
+      end
 
-    rect
+      rect = self.new
+      rect.size = rect1.size
+
+      options[:margins] ||= []
+      margins = {}
+      [:top, :right, :bottom, :left].each_with_index do |margin, index|
+        margins[margin] = options[:margins][index] || 0
+      end
+
+      rect.y = options[:above].up(rect.height + margins[:bottom]).y if options[:above]
+      rect.y = options[:below].below(margins[:top]).y if options[:below]
+
+      rect.x = options[:left_of].left(rect.width + margins[:right]).x if options[:left_of]
+      rect.x = options[:right_of].beside(margins[:left]).x if options[:right_of]
+
+      rect
+    end
+
   end
 
   # bounds

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -102,44 +102,60 @@ class CGRect
   end
 
   # getters/setters
-  def x(setter = nil)
+  def x(setter=nil, options=nil)
     if setter
-      return CGRect.new([setter, self.origin.y], self.size)
+      rect = CGRect.new([setter, self.origin.y], self.size)
+      if options
+        return rect.apply(options)
+      end
+      return rect
     end
-    min_x
+    return min_x
   end
 
   def x=(_x)
     self.origin.x = _x
   end
 
-  def y(setter = nil)
+  def y(setter=nil, options=nil)
     if setter
-      return CGRect.new([self.origin.x, setter], self.size)
+      rect = CGRect.new([self.origin.x, setter], self.size)
+      if options
+        return rect.apply(options)
+      end
+      return rect
     end
-    min_y
+    return min_y
   end
 
   def y=(_y)
     self.origin.y = _y
   end
 
-  def width(setter = nil)
+  def width(setter=nil, options=nil)
     if setter
-      return CGRect.new(self.origin, [setter, self.size.height])
+      rect = CGRect.new(self.origin, [setter, self.size.height])
+      if options
+        return rect.apply(options)
+      end
+      return rect
     end
-    CGRectGetWidth(self)
+    return CGRectGetWidth(self)
   end
 
   def width=(_width)
     self.size.width = _width
   end
 
-  def height(setter = nil)
+  def height(setter=nil, options=nil)
     if setter
-      return CGRect.new(self.origin, [self.size.width, setter])
+      rect = CGRect.new(self.origin, [self.size.width, setter])
+      if options
+        return rect.apply(options)
+      end
+      return rect
     end
-    CGRectGetHeight(self)
+    return CGRectGetHeight(self)
   end
 
   def height=(_height)

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -505,7 +505,7 @@ public
   end
 
   alias grow_right wider
-  def grow_left(amount, options=nil)
+  def grow_left(amount, options={})
     raise "You must specify an amount in `CGRect#grow_left`" unless amount.is_a?(Numeric)
 
     options[:grow_left] = amount
@@ -513,18 +513,18 @@ public
   end
 
   alias grow_down taller
-  def grow_up(amount, options=nil)
+  def grow_up(amount, options={})
     raise "You must specify an amount in `CGRect#grow_up`" unless amount.is_a?(Numeric)
 
     options[:grow_up] = amount
     self.apply(options)
   end
 
-  def grow_width(amount, options=nil)
+  def grow_width(amount, options={})
     return self.grow([amount, 0], options)
   end
 
-  def grow_height(amount, options=nil)
+  def grow_height(amount, options={})
     return self.grow([0, amount], options)
   end
 

--- a/lib/geomotion/version.rb
+++ b/lib/geomotion/version.rb
@@ -1,3 +1,3 @@
 module Geomotion
-  VERSION = "0.13.1"
+  VERSION = "0.13.2"
 end

--- a/spec/cg_point_spec.rb
+++ b/spec/cg_point_spec.rb
@@ -84,6 +84,11 @@ describe "CGPoint" do
       point = CGPoint.make(x: 100, y: 200)
       (@point + point).should == CGPointMake(110, 220)
     end
+
+    it "should work with CGRect" do
+      point = CGRect.make(x: 100, y: 200, width: 50, height: 50)
+      (@point + point).should == CGRectMake(110, 220, 50, 50)
+    end
   end
 
   describe "#*" do

--- a/spec/cg_rect_spec.rb
+++ b/spec/cg_rect_spec.rb
@@ -783,7 +783,6 @@ describe "CGRect" do
   end
 
   describe "#grow_left" do
-    # @rect = CGRect.make(x: 10, y: 100, width: 50, height: 20)
     it "should work" do
       rect = @rect.grow_left(10)
       rect.should == CGRectMake(0, 100, 60, 20)
@@ -828,7 +827,6 @@ describe "CGRect" do
   end
 
   describe "#grow_width" do
-    # @rect = CGRect.make(x: 10, y: 100, width: 50, height: 20)
     it "should work" do
       rect = @rect.grow_width(10)
       rect.should == CGRectMake(0, 100, 70, 20)
@@ -888,7 +886,6 @@ describe "CGRect" do
   end
 
   describe "#shrink_width" do
-    # @rect = CGRect.make(x: 10, y: 100, width: 50, height: 20)
     it "should work" do
       rect = @rect.shrink_width(10)
       rect.should == CGRectMake(20, 100, 30, 20)

--- a/spec/cg_rect_spec.rb
+++ b/spec/cg_rect_spec.rb
@@ -1015,4 +1015,48 @@ describe "CGRect" do
 
   end
 
+  describe "#from_left" do
+    it "should work" do
+      rect = @rect.from_left(width: 10)
+      rect.should == CGRectMake(0, 0, 10, 20)
+    end
+    it "should work with margin" do
+      rect = @rect.from_left(width: 10, margin: 5)
+      rect.should == CGRectMake(5, 0, 10, 20)
+    end
+  end
+
+  describe "#from_right" do
+    it "should work" do
+      rect = @rect.from_right(width: 10)
+      rect.should == CGRectMake(40, 0, 10, 20)
+    end
+    it "should work with margin" do
+      rect = @rect.from_right(width: 10, margin: 5)
+      rect.should == CGRectMake(35, 0, 10, 20)
+    end
+  end
+
+  describe "#from_top" do
+    it "should work" do
+      rect = @rect.from_top(height: 10)
+      rect.should == CGRectMake(0, 0, 50, 10)
+    end
+    it "should work with margin" do
+      rect = @rect.from_top(height: 10, margin: 5)
+      rect.should == CGRectMake(0, 5, 50, 10)
+    end
+  end
+
+  describe "#from_bottom" do
+    it "should work" do
+      rect = @rect.from_bottom(height: 10)
+      rect.should == CGRectMake(0, 10, 50, 10)
+    end
+    it "should work with margin" do
+      rect = @rect.from_bottom(height: 10, margin: 5)
+      rect.should == CGRectMake(0, 5, 50, 10)
+    end
+  end
+
 end

--- a/spec/cg_rect_spec.rb
+++ b/spec/cg_rect_spec.rb
@@ -1037,6 +1037,10 @@ describe "CGRect" do
       rect = @rect.from_left(width: 10, margin: 5)
       rect.should == CGRectMake(5, 0, 10, 20)
     end
+    it "should work with absolute" do
+      rect = @rect.from_left(width: 10, absolute: true)
+      rect.should == CGRectMake(10, 100, 10, 20)
+    end
   end
 
   describe "#from_right" do
@@ -1047,6 +1051,10 @@ describe "CGRect" do
     it "should work with margin" do
       rect = @rect.from_right(width: 10, margin: 5)
       rect.should == CGRectMake(35, 0, 10, 20)
+    end
+    it "should work with absolute" do
+      rect = @rect.from_right(width: 10, absolute: true)
+      rect.should == CGRectMake(50, 100, 10, 20)
     end
   end
 
@@ -1059,6 +1067,10 @@ describe "CGRect" do
       rect = @rect.from_top(height: 10, margin: 5)
       rect.should == CGRectMake(0, 5, 50, 10)
     end
+    it "should work with absolute" do
+      rect = @rect.from_top(height: 10, absolute: true)
+      rect.should == CGRectMake(10, 100, 50, 10)
+    end
   end
 
   describe "#from_bottom" do
@@ -1069,6 +1081,10 @@ describe "CGRect" do
     it "should work with margin" do
       rect = @rect.from_bottom(height: 10, margin: 5)
       rect.should == CGRectMake(0, 5, 50, 10)
+    end
+    it "should work with absolute" do
+      rect = @rect.from_bottom(height: 10, absolute: true)
+      rect.should == CGRectMake(10, 110, 50, 10)
     end
   end
 

--- a/spec/cg_rect_spec.rb
+++ b/spec/cg_rect_spec.rb
@@ -1037,6 +1037,10 @@ describe "CGRect" do
       rect = @rect.from_left(width: 10, margin: 5)
       rect.should == CGRectMake(5, 0, 10, 20)
     end
+    it "should work with all options" do
+      rect = @rect.from_left(width: 10, shrink_down: 5)
+      rect.should == CGRectMake(0, 5, 10, 15)
+    end
     it "should work with absolute" do
       rect = @rect.from_left(width: 10, absolute: true)
       rect.should == CGRectMake(10, 100, 10, 20)
@@ -1051,6 +1055,10 @@ describe "CGRect" do
     it "should work with margin" do
       rect = @rect.from_right(width: 10, margin: 5)
       rect.should == CGRectMake(35, 0, 10, 20)
+    end
+    it "should work with all options" do
+      rect = @rect.from_right(width: 10, shrink_down: 5)
+      rect.should == CGRectMake(40, 5, 10, 15)
     end
     it "should work with absolute" do
       rect = @rect.from_right(width: 10, absolute: true)
@@ -1067,6 +1075,10 @@ describe "CGRect" do
       rect = @rect.from_top(height: 10, margin: 5)
       rect.should == CGRectMake(0, 5, 50, 10)
     end
+    it "should work with all options" do
+      rect = @rect.from_top(height: 10, shrink_right: 5)
+      rect.should == CGRectMake(5, 0, 45, 10)
+    end
     it "should work with absolute" do
       rect = @rect.from_top(height: 10, absolute: true)
       rect.should == CGRectMake(10, 100, 50, 10)
@@ -1081,6 +1093,10 @@ describe "CGRect" do
     it "should work with margin" do
       rect = @rect.from_bottom(height: 10, margin: 5)
       rect.should == CGRectMake(0, 5, 50, 10)
+    end
+    it "should work with all options" do
+      rect = @rect.from_bottom(height: 10, shrink_right: 5)
+      rect.should == CGRectMake(5, 10, 45, 10)
     end
     it "should work with absolute" do
       rect = @rect.from_bottom(height: 10, absolute: true)

--- a/spec/cg_rect_spec.rb
+++ b/spec/cg_rect_spec.rb
@@ -788,12 +788,20 @@ describe "CGRect" do
       rect = @rect.grow_left(10)
       rect.should == CGRectMake(0, 100, 60, 20)
     end
+    it "should work with options" do
+      rect = @rect.grow_left(10, height: 5)
+      rect.should == CGRectMake(0, 100, 60, 5)
+    end
   end
 
   describe "#grow_right" do
     it "should work" do
       rect = @rect.grow_right(10)
       rect.should == CGRectMake(10, 100, 60, 20)
+    end
+    it "should work with options" do
+      rect = @rect.grow_right(10, height: 5)
+      rect.should == CGRectMake(10, 100, 60, 5)
     end
   end
 
@@ -802,12 +810,20 @@ describe "CGRect" do
       rect = @rect.grow_up(10)
       rect.should == CGRectMake(10, 90, 50, 30)
     end
+    it "should work with options" do
+      rect = @rect.grow_up(10, width: 5)
+      rect.should == CGRectMake(10, 90, 5, 30)
+    end
   end
 
   describe "#grow_down" do
     it "should work" do
       rect = @rect.grow_down(10)
       rect.should == CGRectMake(10, 100, 50, 30)
+    end
+    it "should work with options" do
+      rect = @rect.grow_down(10, width: 5)
+      rect.should == CGRectMake(10, 100, 5, 30)
     end
   end
 


### PR DESCRIPTION
The `from_*` methods create a frame inside the receiver, with optional margin, and one required dimension.  e.g.

``` ruby
rect = CGRect.make(x: 10, y: 10, width: 10, height: 10)
rect.from_right(width: 5, margin: 2)  # width is a required option
# => [[3, 0], [5, 10]]
# the resulting frame is *inside* the receiver, just like the other methods, unless the absolute option is true
rect.from_right(width: 5, margin: 2, absolute: true)
# => [[13, 10], [5, 10]]
```

And misc specs and fixes.  Bumped version to 0.13.2
