### PR TITLE
(fix) allows ':margin' as option in above, below, before, beside

### DIFF
--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -347,6 +347,7 @@ class CGRect
       right: self.size.width + margin
       }.merge(options))
   end
+  alias after beside
 
   # these methods create a rect INSIDE the receiver
 
@@ -533,6 +534,7 @@ public
   end
 
   alias grow_right wider
+
   def grow_left(amount, options={})
     raise "You must specify an amount in `CGRect#grow_left`" unless amount.is_a?(Numeric)
 
@@ -542,6 +544,7 @@ public
   end
 
   alias grow_down taller
+
   def grow_up(amount, options={})
     raise "You must specify an amount in `CGRect#grow_up`" unless amount.is_a?(Numeric)
 
@@ -570,6 +573,7 @@ public
   end
 
   alias shrink_left thinner
+
   def shrink_right(amount, options={})
     raise "You must specify an amount in `CGRect#shrink_right`" unless amount.is_a?(Numeric)
 
@@ -579,6 +583,7 @@ public
   end
 
   alias shrink_up shorter
+
   def shrink_down(amount, options={})
     raise "You must specify an amount in `CGRect#shrink_down`" unless amount.is_a?(Numeric)
 

--- a/lib/geomotion/cg_rect.rb
+++ b/lib/geomotion/cg_rect.rb
@@ -312,6 +312,7 @@ class CGRect
   # adjacent rects
   def above(margin = 0, options={})
     margin, options = 0, margin if margin.is_a?(NSDictionary)
+    margin = options.delete(:margin) if options.key?(:margin)
 
     height = options[:height] || self.size.height
     self.apply({
@@ -321,6 +322,7 @@ class CGRect
 
   def below(margin = 0, options={})
     margin, options = 0, margin if margin.is_a?(NSDictionary)
+    margin = options.delete(:margin) if options.key?(:margin)
 
     self.apply({
       down: self.size.height + margin
@@ -329,6 +331,7 @@ class CGRect
 
   def before(margin = 0, options={})
     margin, options = 0, margin if margin.is_a?(NSDictionary)
+    margin = options.delete(:margin) if options.key?(:margin)
 
     width = options[:width] || self.size.width
     self.apply({
@@ -338,6 +341,7 @@ class CGRect
 
   def beside(margin = 0, options={})
     margin, options = 0, margin if margin.is_a?(NSDictionary)
+    margin = options.delete(:margin) if options.key?(:margin)
 
     self.apply({
       right: self.size.width + margin

--- a/lib/geomotion/version.rb
+++ b/lib/geomotion/version.rb
@@ -1,3 +1,3 @@
 module Geomotion
-  VERSION = "0.13.2"
+  VERSION = "0.13.3"
 end

--- a/spec/cg_rect_spec.rb
+++ b/spec/cg_rect_spec.rb
@@ -414,6 +414,12 @@ describe "CGRect" do
       rect.origin.y.should == -10
       rect.size.height.should == 10
     end
+
+    it "works with options and margin as option" do
+      rect = CGRect.make(height: 50).above(margin: 20, height: 10)
+      rect.origin.y.should == -30
+      rect.size.height.should == 10
+    end
   end
 
   describe "#below" do
@@ -438,6 +444,12 @@ describe "CGRect" do
     it "works with options and no margin" do
       rect = CGRect.make(height: 50).below(height: 10)
       rect.origin.y.should == 50
+      rect.size.height.should == 10
+    end
+
+    it "works with options and margin as option" do
+      rect = CGRect.make(height: 50).below(margin: 20, height: 10)
+      rect.origin.y.should == 70
       rect.size.height.should == 10
     end
   end
@@ -466,6 +478,12 @@ describe "CGRect" do
       rect.origin.x.should == -10
       rect.size.width.should == 10
     end
+
+    it "works with options and margin as option" do
+      rect = CGRect.make(width: 50).before(margin: 20, width: 10)
+      rect.origin.x.should == -30
+      rect.size.width.should == 10
+    end
   end
 
   describe "#beside" do
@@ -490,6 +508,12 @@ describe "CGRect" do
     it "works with options and no margin" do
       rect = CGRect.make(width: 50).beside(width: 10)
       rect.origin.x.should == 50
+      rect.size.width.should == 10
+    end
+
+    it "works with options and margin as option" do
+      rect = CGRect.make(width: 50).beside(margin: 20, width: 10)
+      rect.origin.x.should == 70
       rect.size.width.should == 10
     end
   end


### PR DESCRIPTION
How are things, Clay!  I hope you're well.  Just a minor "feature", to support margin as a key in the options dict.
